### PR TITLE
zoomの日程編集の開始時間をバリデーション

### DIFF
--- a/laravel/app/Http/Controllers/Zoom/MeetingController.php
+++ b/laravel/app/Http/Controllers/Zoom/MeetingController.php
@@ -11,6 +11,7 @@ use App\Meeting;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\MeetingRequest;
 
 
 class MeetingController extends Controller
@@ -116,7 +117,7 @@ class MeetingController extends Controller
         ]);
     }
 
-    public function update(Request $request, Meeting $meeting, $id)
+    public function update(MeetingRequest $request, Meeting $meeting, $id)
     {
         $email = env('ZOOM_ACCOUNT_EMAIL');
         $meeting = Meeting::find($id);

--- a/laravel/app/Http/Requests/MeetingRequest.php
+++ b/laravel/app/Http/Requests/MeetingRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MeetingRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'start_time' => 'required',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'start_time' => '開始時間'
+        ];
+    }
+}


### PR DESCRIPTION
編集画面に入ると初期値はnullなので、そのまま編集するとエラーが発生。

バリデーションでMeetingRequestを追加して、開始時間にrequiredを追加